### PR TITLE
fix: fix test of rotate-matrix function

### DIFF
--- a/test/conditions-n-loops-tests.js
+++ b/test/conditions-n-loops-tests.js
@@ -428,8 +428,7 @@ describe('core-js-conditions-n-loops', () => {
         [8, 5, 2],
         [9, 6, 3],
       ];
-      tasks.rotateMatrix(arr);
-      assert.deepEqual(arr, result);
+      assert.deepEqual(tasks.rotateMatrix(arr), result);
       const min = -10;
       const max = 10;
       const matrixSize = 5;
@@ -440,8 +439,7 @@ describe('core-js-conditions-n-loops', () => {
           arr.push(line);
         }
         result = utility.getRotateMatrixUtil(arr);
-        tasks.rotateMatrix(arr);
-        assert.deepEqual(arr, result);
+        assert.deepEqual(tasks.rotateMatrix(arr), result);
       }
       assert.equal(
         forbidden.isCommented(tasks.rotateMatrix),


### PR DESCRIPTION
### I think the test of the `rotateMatrix` function has a bug.  

According to the test, we need to modify the matrix which we are receiving from the parameter of the function. However, ESLint does not allow us to do so. which gives an error.

When I tried to return a rotated matrix, it showed that my function did not pass the test. But my function works correctly.